### PR TITLE
WIP: remove redis dependancy and update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/*
 .idea/
 coverage/
 .nyc_output
+dist/*
+.nvmrc

--- a/README.md
+++ b/README.md
@@ -7,7 +7,78 @@ Middleware based cache implementation using Redis for [Lux](https://github.com/p
 
 ## Usage
 
-> TODO: fill in a good example here.
+Here is an example of a api wide implementation of the middleware, excluding specific routes.  and a basic redis util to pass into the middleware.  Currently you must initialize and provide your own promisifyAll'd redis client instance.
+
+
+app/controllers/application.js
+
+```js
+import { Controller } from 'lux-framework';
+import unless from 'lux-unless';
+import redis from 'app/utils/redis';
+import { getFromRedis, addToRedis } from 'lux-redis-cache';
+
+const { REDIS_CACHE_EXPIRES_IN = 600 } = process.env; // 600 = 10 minutes
+
+const pathsToNotCache = [
+  '/auth/login',
+  '/auth/token-refresh',
+  /product-(variants|separates)/gi,
+  /sync-logs/gi
+];
+
+class ApplicationController extends Controller {
+  beforeAction = [
+    ...,
+    unless({
+      path: pathsToNotCache,
+      method: ['OPTIONS']
+    }, getFromRedis({
+      naiveCacheExpiry: false,
+      redis
+    }))
+  ];
+  afterAction = [
+    ...
+    addToRedis({ expiresIn: REDIS_CACHE_EXPIRES_IN })
+  ];
+}
+
+export default ApplicationController;
+```
+
+
+// app/utils/redis.js
+
+```js
+// load your env vars if needed.
+// import dotenv from './dotenv';
+// dotenv();
+
+import bluebird from 'bluebird';
+import redis from 'redis';
+let client;
+
+if (typeof client !== 'object') {
+  const {
+    REDIS_HOST,
+    REDIS_PORT
+  } = process.env;
+
+  try {
+    client = redis.createClient(REDIS_PORT, REDIS_HOST);
+  } catch (e) {
+    debug('exception creating client: ', e);
+  }
+
+  bluebird.promisifyAll(redis.RedisClient.prototype);
+  bluebird.promisifyAll(redis.Multi.prototype);
+}
+
+
+export default client;
+```
+
 
 ## Related Modules
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# lux-jwt
-Middleware implementation of Redis for [Lux](https://github.com/postlight/lux).
+# lux-redis-cache
+Middleware based cache implementation using Redis for [Lux](https://github.com/postlight/lux).
 
 ## Install
 
-    $ npm i --save lux-redis
+    $ npm i --save lux-redis-cache
 
 ## Usage
+
+> TODO: fill in a good example here.
 
 ## Related Modules
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,56 @@
-import redis from './utils/redis';
-
+const { has } = Reflect;
 /*
  * Middleware to automatically cache routes to Redis.
  * Initialize it in a beforeAction and afterAction hook.
  */
 
 let currentCacheKey = Date.now();
+const cacheKey = 'cache';
+let _redis, get, set, scan, del;
+
+function initializeRedis(redis) {
+  if (!redis) {
+    throw new Error('must provide valid redis instance.');
+  }
+
+  _redis = redis;
+
+  if (!has(_redis, 'set')) {
+    throw new Error('we expected redis to have a set function!');
+  }
+
+  set = _redis.set;
+
+  if (has(_redis, 'getAsync')) {
+    get = _redis.getAsync;
+  } else {
+    get = function(key) {
+      return new Promise((resolve, reject) => {
+        _redis.get(key).then(resolve).catch(reject);
+      });
+    };
+  }
+
+  if (has(_redis, 'scanAsync')) {
+    scan = _redis.scanAsync;
+  } else {
+    scan = function() {
+      return new Promise((resolve, reject) => {
+        _redis.scan(...arguments).then(resolve).catch(reject);
+      });
+    };
+  }
+
+  if (has(_redis, 'delAsync')) {
+    del = _redis.delAsync;
+  } else {
+    del = function() {
+      return new Promise((resolve, reject) => {
+        _redis.del(...arguments).then(resolve).catch(reject);
+      });
+    };
+  }
+}
 
 /**
  * Method meant to be used in any place where you wan't to retrieve something
@@ -15,8 +60,14 @@ let currentCacheKey = Date.now();
  */
 export function getFromRedis(options = {}) {
   const {
-    naiveCacheExpiry = true
+    naiveCacheExpiry = true,
+    redis
   } = options;
+
+  // initializeRedis is broken still. :(
+  // initializeRedis(redis);
+
+  _redis = redis;
 
   return async (request, response) => {
     const {
@@ -37,7 +88,7 @@ export function getFromRedis(options = {}) {
 
       // only cache controllers with model for now
       if(model){
-        let key = `${model.modelName}:${path}`;
+        let key = `${cacheKey}:${model.modelName}:${path}`;
 
         if(naiveCacheExpiry){
           key += `:${currentCacheKey}`;
@@ -45,7 +96,7 @@ export function getFromRedis(options = {}) {
 
         key += `:${new Buffer.from(JSON.stringify(params)).toString('base64')}`;
 
-        const payload = await redis.getAsync(key);
+        const payload = await _redis.getAsync(key);
 
         if(payload){
           return JSON.parse(payload);
@@ -66,7 +117,8 @@ export function getFromRedis(options = {}) {
  */
 export function addToRedis(options = {}){
   const {
-    expiresIn = 0
+    expiresIn = 0,
+    redis
   } = options;
 
   return async (request, response, payload) => {
@@ -81,7 +133,7 @@ export function addToRedis(options = {}){
         args.push('EX', expiresIn);
       }
 
-      redis.set(args);
+      _redis.set(args);
     } else if(
          action === 'update'
       || action === 'create'
@@ -104,23 +156,28 @@ export function addToRedis(options = {}){
  * @param modelName The name of the model for which the keys need to be deleted.
  * @returns {Promise.<void>}
  */
-export async function modelAfterSaveDeleteFromRedis(modelName){
-  let cursor = '0';
-  let keys = [];
-  do {
-    let result =  await redis.scanAsync(
-      cursor,
-      'MATCH', `${modelName}:*`
-    );
+ export async function modelAfterSaveDeleteFromRedis(modelName){
+   let cursor = '0';
+   let keys = [];
+   // console.log('cleaning up model: ', modelName);
+   do {
+     let result =  await _redis.scanAsync(
+       cursor,
+       'MATCH',
+       `${cacheKey}:${modelName}:*`
+     );
 
-    cursor = result[0];
-    keys = keys.concat(result[1]);
-  } while (cursor !== '0');
+     cursor = result[0];
+     keys = keys.concat(result[1]);
+   } while (cursor !== '0');
 
-  redis.delAsync(keys);
-}
+   if (keys && keys.length > 0) {
+     _redis.delAsync(keys);
+   }
 
-/**
- * Export the redis client
- */
-export { redis };
+ }
+
+// /**
+//  * Export the redis client
+//  */
+// export { redis };

--- a/lib/utils/redis.js
+++ b/lib/utils/redis.js
@@ -1,7 +1,0 @@
-import bluebird from 'bluebird';
-import redis from 'redis';
-
-export default redis.createClient(process.env.REDIS_URL);
-
-bluebird.promisifyAll(redis.RedisClient.prototype);
-bluebird.promisifyAll(redis.Multi.prototype);

--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
   "engines": {
     "node": ">= 6.0"
   },
-  "dependencies": {
-    "bluebird": "^3.5.0",
-    "redis": "^2.7.1"
-  },
+  "dependencies": { },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-async-to-generator": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": "github:nickschot/lux-redis-cache",
   "bugs": {
-    "url": "http://github.com/nickschot/lux-redis/issues"
+    "url": "http://github.com/nickschot/lux-redis-cache/issues"
   },
   "author": "Nick Schot",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "lux-redis",
+  "name": "lux-redis-cache",
   "version": "0.1.0",
-  "description": "Redis middleware.",
+  "description": "Redis caching middleware.",
   "keywords": [
     "redis",
     "lux",
     "lux-middleware"
   ],
-  "repository": "github:nickschot/lux-redis",
+  "repository": "github:nickschot/lux-redis-cache",
   "bugs": {
     "url": "http://github.com/nickschot/lux-redis/issues"
   },


### PR DESCRIPTION
a start to refactoring out redis locally and a few other updates... 

FYI: using the `initializeRedis` method (in index.js) which is currently commented out is broken and might be a faulty approach to making a bluebird promisified version of the redis instance optional.