### PR TITLE
new: add enabled option (fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Another option is to use a simple timed expiration. You can disable the naïve c
 - **options** - Options object
   - **cacheKey** *(default: 'cache')* - The name of the top level key for redis
   - **naiveCacheExpiry** *(default: true)* - Set to false to disable naïve cache expiry
+  - **enabled** *(default: true)* - Set to false to disable cache entirely
 
 ### addToRedis(redis, options)
 `addToRedis` is meant to be used in an `afterAction` hook. It will add the response data to redis if the `getFromRedis` middleware detected the cache entry was missing. You can also pass an expiration time in the options object in order for your cache entries to expire in a certain number of seconds. This is meant mainly for when you don't use the naïve cache expiry.

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,8 @@ let currentCacheKey = Date.now();
 export function getFromRedis(redis, options = {}) {
   const {
     cacheKey = 'cache',
-    naiveCacheExpiry = true
+    naiveCacheExpiry = true,
+    enabled = true
   } = options;
 
   return async (request, response) => {
@@ -27,7 +28,7 @@ export function getFromRedis(redis, options = {}) {
       }
     } = request;
 
-    if(method === 'GET' && (action === 'index' || action === 'show')){
+    if(enabled && method === 'GET' && (action === 'index' || action === 'show')){
       const {
         params,
         controller: {


### PR DESCRIPTION
this PR adds a boolean enabled option to the `getFromRedis` middleware function, which inherently also disables the `addToRedis` function as the request param to trigger the caching never gets set.

The option is enabled by default.

example usage: 
```js
getFromRedis(redis, {
  naiveCacheExpiry: false,
  enabled: process.env.REDIS_CACHE_ENABLED || true
})
```