### PR TITLE
add timeBased expiration strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ The cache expiration works as follows for the different actions.
 - **Create/Update action:** expire the model and direct belongsTo and hasMany relationships
 - **Destroy:** expire the whole cache, the database could be configured to CASCADE on delete, so we don't know what needs to be expired
 
+#### Time Based Cache Expiry
+This is a very simple cache strategy where we simply use the `expiresIn` option passed into `getFromRedis`.  No cache invalidation is provided with this strategy.
+
 ### getFromRedis(redis, options)
-`getFromRedis` is meant to be used in a `beforeAction` hook. It will try to get data from redis for any `GET` request from on an `index` or `show` controller action. It will immediately return the payload while the action/afterAction is skipped. 
+`getFromRedis` is meant to be used in a `beforeAction` hook. It will try to get data from redis for any `GET` request from on an `index` or `show` controller action. It will immediately return the payload while the action/afterAction is skipped.
 
 - **redis** - A connected node-redis instance
 - **options** - Options object
@@ -67,7 +70,7 @@ class ApplicationController extends Controller {
   beforeAction = [
       getFromRedis(redis)
   ];
-  
+
   afterAction = [
       addToRedis()
   ];

--- a/lib/cache-engines/time-based.js
+++ b/lib/cache-engines/time-based.js
@@ -1,0 +1,20 @@
+/*
+ * Time based Expiry
+ */
+
+export function buildKey(cacheKey, request) {
+  const {
+    url: {
+      path
+    },
+    controller: {
+      model
+    }
+  } = request;
+
+  return `${cacheKey}:${model.modelName}:${path}`;
+}
+
+export function expireKeys(request, payload){
+  // noop as we rely on the redis expiration time here.
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 import * as naiveCacheExpiry from './cache-engines/naive-cache-expiry';
 import * as relationshipBasedCacheExpiry from './cache-engines/relationship-based-cache-expiry';
-
+import * as timeBased from './cache-engines/time-based';
 /*
  * Middleware to automatically cache routes to Redis.
  * Initialize it in a beforeAction and afterAction hook.
@@ -9,7 +9,8 @@ import * as relationshipBasedCacheExpiry from './cache-engines/relationship-base
 const requestKey = 'luxRedisCache';
 const cacheEngines = new Map([
   ['naiveCacheExpiry', naiveCacheExpiry],
-  ['relationshipBasedCacheExpiry', relationshipBasedCacheExpiry]
+  ['relationshipBasedCacheExpiry', relationshipBasedCacheExpiry],
+  ['timeBased', timeBased]
 ]);
 
 /**


### PR DESCRIPTION
very simple cache strategy purely based on redis expiration time.  Implementor can manually remove cache items from redis outside of the scope of `lux-redis-cache` if desired.