### PR TITLE
don't throw errors if there is no request key in `addToRedis` (fix #12)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -105,13 +105,7 @@ export function addToRedis(){
     } = request;
 
     if(method !== 'OPTIONS'){
-      if(!request[requestKey]){
-        throw new Error(`lux-redis-cache: No lux-redis-cache options found on
-         the request object. Make sure you added getFromRedis in the right 
-         place!`);
-      }
-
-      if(request[requestKey].enabled){
+      if(request[requestKey] && request[requestKey].enabled){
         const redis               = request[requestKey].redisInstance;
         const cacheEngineInstance = request[requestKey].cacheEngineInstance;
         const expiresIn           = request[requestKey].expiresIn;


### PR DESCRIPTION
we like `lux-unless` and should allow people to use it with this, but not too much where they have to use it twice for before AND after action.  That's just getting unruly.  ;) 